### PR TITLE
Feat(backend): startup routines

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -4,3 +4,6 @@ __pycache__
 # Temp files
 *.sql
 *.txt
+
+# Log file
+api.log

--- a/backend/src/database.py
+++ b/backend/src/database.py
@@ -13,7 +13,7 @@ class QuickParkingDB():
     '''
     def __init__(self, conninfo) -> None:
         self._connection_pools = ConnectionPool(conninfo)
-        print('DEBUG: Starting DB')
+        self._connection_pools.wait()
 
     def add_user(self, first_name: str, last_name: str, email: str, phone_num: str,
                 gender: Gender, age: int, job_title: Role, special_role: str) -> int:
@@ -97,5 +97,3 @@ class QuickParkingDB():
                 # Close the cursor and the connection
                 cursor.close()
                 conn.close()
-
-database = QuickParkingDB(DB_CONNECT)

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -6,7 +6,7 @@ from fastapi import FastAPI
 from src.users.router import router as user_router
 from src.spaces.router import router as spaces_router
 from src.parking.router import router as parking_router
-
+from src.database import QuickParkingDB, DB_CONNECT
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
@@ -26,7 +26,10 @@ async def lifespan(app: FastAPI):
     )
     handler.setFormatter(logging.Formatter("%(asctime)s - %(levelname)s - %(message)s"))
     logger.addHandler(handler)
-    
+
+    # set up database
+    app.state.database = QuickParkingDB(DB_CONNECT)
+
     yield
     '''Shutdown Routines'''
 

--- a/backend/src/parking/router.py
+++ b/backend/src/parking/router.py
@@ -1,23 +1,22 @@
 '''User management module'''
 from datetime import datetime
-from fastapi import APIRouter
-from src.database import database
+from fastapi import APIRouter, Request
 
 router = APIRouter()
 
 
 @router.post("/parking/{slot_id}")
-def park(plate_num: str, slot_id: int):
+def park(r: Request, plate_num: str, slot_id: int):
     '''Park a car in a slot'''
     start_time = str(datetime.now())
-    record_id = database.park_car(plate_num, slot_id, start_time)
+    record_id = r.app.state.database.park_car(plate_num, slot_id, start_time)
 
     return {"record_id": record_id, 'start_time': start_time}
 
 @router.put("/parking/{slot_id}")
-def pick(slot_id: int):
+def pick(r: Request, slot_id: int):
     '''Pick a car according to the record id'''
     end_time = str(datetime.now())
-    database.pick_car(slot_id, end_time)
+    r.app.state.database.pick_car(slot_id, end_time)
 
     return {"end_time": end_time}

--- a/backend/src/spaces/router.py
+++ b/backend/src/spaces/router.py
@@ -1,11 +1,10 @@
 '''Parking Space Management Module'''
-from fastapi import APIRouter
-from src.database import database
+from fastapi import APIRouter, Request
 
 router = APIRouter()
 
 
 @router.get(path="/spaces/")
-def read_free_spaces(parkinglot_id: int):
+def read_free_spaces(r: Request, parkinglot_id: int):
     '''Returns a list of free spaces of a parking lot'''
-    return database.get_free_spaces(parkinglot_id)
+    return r.app.state.database.get_free_spaces(parkinglot_id)

--- a/backend/src/users/router.py
+++ b/backend/src/users/router.py
@@ -1,16 +1,15 @@
 '''User management module'''
-from fastapi import APIRouter
+from fastapi import APIRouter, Request
 from src.users.constants import Role, Gender
-from src.database import database
 
 router = APIRouter()
 
 
 @router.post("/users/registration")
-def create_user(first_name: str, last_name: str, email: str, phone_num: str,
+def create_user(r: Request, first_name: str, last_name: str, email: str, phone_num: str,
                 gender: Gender, age: int, job_title: Role, special_role: str = "None"):
     '''Create a new user'''
-    user_id = database.add_user(first_name, last_name, email, phone_num,
+    user_id = r.app.state.database.add_user(first_name, last_name, email, phone_num,
                        gender, age, job_title, special_role)
 
     return {"user_id": user_id}


### PR DESCRIPTION
This PR added a startup routines which includes
- set up routers
- set up logging output
- prepare database connection pool

Instead of using global objects, store them inside `app` when the app starts up.
To access them in the router,  apis need to include `fastapi.Request` as a parameter `r`, and access the app objects like database via `r.app.state.database`.

[More](https://github.com/tiangolo/fastapi/discussions/8239)