### PR TITLE
refactor(backend): update user related api naming

### DIFF
--- a/backend/src/constants.py
+++ b/backend/src/constants.py
@@ -104,8 +104,8 @@ class Gender(str, Enum):
     FEMALE = "female"
 
 
-class UserRequest(BaseModel):
-    '''User request data'''
+class UserData(BaseModel):
+    '''User info data'''
     user_id: str
     name: str
     email: str

--- a/backend/src/users/router.py
+++ b/backend/src/users/router.py
@@ -1,29 +1,29 @@
 '''User management module'''
 from fastapi import APIRouter, Request
 from src.users.utils import get_user_favorite_parkinglot
-from src.constants import UserRequest, UserInfo
+from src.constants import UserData, UserInfo
 
 router = APIRouter()
 
 
 @router.post("/users/")
-def create_user(r: Request, user_request: UserRequest) -> dict[str, str]:
+def create_user(r: Request, user_data: UserData) -> dict[str, str]:
     '''Create a new user'''
-    user_id = r.app.state.database.add_user(user_request.user_id, user_request.name,
-                                            user_request.email, user_request.phone_num,
-                                            user_request.gender, user_request.age,
-                                            user_request.job_title, user_request.special_role)
+    user_id = r.app.state.database.add_user(user_data.user_id, user_data.name,
+                                            user_data.email, user_data.phone_num,
+                                            user_data.gender, user_data.age,
+                                            user_data.job_title, user_data.special_role)
 
     return {"user_id": user_id}
 
 
-@router.put("/users/{user_id}")
-def update_user(r: Request, user_id: str, user_request: UserRequest) -> None:
+@router.put("/users/")
+def update_user(r: Request, user_data: UserData) -> None:
     '''Update user information'''
-    r.app.state.database.update_user(user_id, user_request.name,
-                                     user_request.email, user_request.phone_num,
-                                     user_request.gender, user_request.age,
-                                     user_request.job_title, user_request.special_role)
+    r.app.state.database.update_user(user_data.user_id, user_data.name,
+                                     user_data.email, user_data.phone_num,
+                                     user_data.gender, user_data.age,
+                                     user_data.job_title, user_data.special_role)
 
 
 @router.delete("/users/{user_id}")
@@ -32,7 +32,7 @@ def delete_user(r: Request, user_id: str) -> None:
     user_id = r.app.state.database.delete_user(user_id)
 
 
-@router.get("/users/{user_id}")
+@router.get("/users/page_info/{user_id}")
 def get_user_info(r: Request, user_id: str) -> UserInfo:
     '''Get user information'''
     # Get user's favorite parking lot

--- a/backend/src/users/utils.py
+++ b/backend/src/users/utils.py
@@ -5,6 +5,6 @@ def get_user_favorite_parkinglot() -> list[BuildingInfo]:
     '''Get user's favorite parking lot'''
     # This function will be updated later
     return [
-        BuildingInfo(0, "Building A", 30),
-        BuildingInfo(1, "Factory B", 80)
+        BuildingInfo(1, "Building A", 30),
+        BuildingInfo(2, "Factory B", 80)
     ]

--- a/backend/tests/users/test_router.py
+++ b/backend/tests/users/test_router.py
@@ -45,5 +45,5 @@ def test_update_user(mocker, mock_db, user_data):
     mocker.patch("src.main.QuickParkingDB", return_value=mock_db)
 
     with TestClient(app) as client:
-        response = client.put("/api/users/1", json=user_data)
+        response = client.put("/api/users/", json=user_data)
         assert response.status_code == 200

--- a/frontend/src/pages/Home/index.tsx
+++ b/frontend/src/pages/Home/index.tsx
@@ -63,7 +63,7 @@ const Home = ({ instance }: any): React.ReactElement => {
 
   useEffect(() => {
     const id = '21EC2020-3AEA-1069-A2DD-08002B30309D'
-    axios.get<UserInfo>(`users/${id}`)
+    axios.get<UserInfo>(`users/page_info/${id}`)
       .then(response => {
         setUserInfo(response.data)
       })


### PR DESCRIPTION
What I do in this PR:

1. Change **update_user** api, now you need to pass the user_id in the request body instead of path parameter.
2. Change **get_user_info** api from `/users/{user_id} `to `/users/page_info/{user_id}.`